### PR TITLE
Fixed Swift dynamic casting problem

### DIFF
--- a/RealmTest.xcodeproj/project.pbxproj
+++ b/RealmTest.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 		B51F6BD31A6DB6A900B2DA53 /* RealmTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51F6BD21A6DB6A900B2DA53 /* RealmTestCase.swift */; };
 		B51F6BDD1A6DB6EC00B2DA53 /* TestUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51F6BDC1A6DB6EC00B2DA53 /* TestUser.swift */; };
 		B51F6BE31A6DB95500B2DA53 /* TestUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51F6BE21A6DB95500B2DA53 /* TestUserTests.swift */; };
-		B529030A1A6DCB3E0046B7BA /* TestUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51F6BDC1A6DB6EC00B2DA53 /* TestUser.swift */; };
 		CD8659FADB81383ECA95E23A /* libPods-RealmTest.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A86CF4969395D313B210462 /* libPods-RealmTest.a */; };
 /* End PBXBuildFile section */
 
@@ -332,7 +331,6 @@
 			files = (
 				B51F6BE31A6DB95500B2DA53 /* TestUserTests.swift in Sources */,
 				B51F6BD31A6DB6A900B2DA53 /* RealmTestCase.swift in Sources */,
-				B529030A1A6DCB3E0046B7BA /* TestUser.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RealmTest/TestUser.swift
+++ b/RealmTest/TestUser.swift
@@ -6,14 +6,14 @@
 //  Copyright (c) 2015 bredfield. All rights reserved.
 //
 
-class TestUser: RLMObject {
+public class TestUser: RLMObject {
     dynamic var token = ""
     
     struct defaults {
         static let tokenKey = "userToken"
     }
     
-    override class func primaryKey() -> String {
+    public override class func primaryKey() -> String {
         return "token"
     }
     
@@ -29,7 +29,7 @@ class TestUser: RLMObject {
 
 //Creation & Deletion
 extension TestUser {
-    class func createUserWithToken(token: String)-> TestUser {
+    public class func createUserWithToken(token: String)-> TestUser {
         let user = TestUser(token)
         
         let realm = RLMRealm.defaultRealm()
@@ -49,7 +49,7 @@ extension TestUser {
         realm.commitWriteTransaction()
     }
     
-    class func currentUser(token: String) -> TestUser? {
+    public class func currentUser(token: String) -> TestUser? {
         let predicate = NSPredicate(format: "token = %@", token)
         return TestUser.objectsWithPredicate(predicate).firstObject() as? TestUser
     }

--- a/RealmTestTests/TestUserTests.swift
+++ b/RealmTestTests/TestUserTests.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import XCTest
+import RealmTest
 
 class TestUserTests: RealmTestCase {
 
@@ -28,7 +29,6 @@ class TestUserTests: RealmTestCase {
         
         let predicate = NSPredicate(format: "token = %@", token)
         let user = TestUser.objectsWithPredicate(predicate).firstObject() as? TestUser
-        //This sporadically passes/fails
         XCTAssert(user != nil, "User should exist")
     }
 }


### PR DESCRIPTION
**tl;dr; don't add your app's Swift files to your unit test targets.**

In Swift, classes are namespaced by the module (`ModuleName.ClassName`), which means that `RealmTest.TestUser` is technically a different class than `RealmTestTests.TestUser`. In turn, this causes Swift's dynamic casting (`as?`) to occasionally fail.

So instead of adding `TestUser.swift` to the unit test target (which causes it to be recompiled and two copies of the same class to be available), just make it `public` and import the module where it's being compiled into the test target.

To recap: in general, declare testable code written in Swift as `public` to expose it to your test targets, and don't recompile files with testable code in your test targets.

See a [note from the Swift testing framework Quick](https://github.com/Quick/Quick/blob/master/Documentation/SettingUpYourXcodeProject.md#testing-swift-code-using-swift) and [this StackOverflow comment](http://stackoverflow.com/questions/28733016/view-controller-tdd/28750266?noredirect=1#comment45781022_28736395) for more details.
